### PR TITLE
Simplify Setup of Acima Payment Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ For most projects we recommend using a static source, so that sensitive account 
 # config/initializers/solidus_acima.rb
 SolidusAcima.configure do |config|
   config.acima_merchant_id =    ENV['ACIMA_MERCHANT_ID']
-  config.acima_iframe_url =     ENV['ACIMA_IFRAME_URL']
   config.acima_client_id =      ENV['ACIMA_CLIENT_ID']
   config.acima_client_secret =  ENV['ACIMA_CLIENT_SECRET']
   config.acima_payment_method = Spree::PaymentMethod.find(ENV['ACIMA_PAYMENT_METHOD_ID'])
@@ -43,7 +42,6 @@ Spree::Config.configure do |config|
     SolidusAcima::PaymentMethod,
     'acima_credentials', {
       merchant_id: SolidusAcima.config.acima_merchant_id,
-      iframe_url: SolidusAcima.config.acima_iframe_url,
       client_id: SolidusAcima.config.acima_client_id,
       client_secret: SolidusAcima.config.acima_client_secret
     }

--- a/app/models/solidus_acima/gateway.rb
+++ b/app/models/solidus_acima/gateway.rb
@@ -7,7 +7,7 @@ module SolidusAcima
     attr_reader :api_url, :acima_bearer_token
 
     def initialize(options)
-      sandbox = options[:iframe_url].include?('sandbox') ? '-sandbox' : ''
+      sandbox = options[:test_mode] ? '-sandbox' : ''
       @api_url = "https://api#{sandbox}.acimacredit.com/api"
       @acima_bearer_token = generate_bearer_token(options[:client_id], options[:client_secret])
     end

--- a/app/models/solidus_acima/payment_method.rb
+++ b/app/models/solidus_acima/payment_method.rb
@@ -3,13 +3,8 @@
 module SolidusAcima
   class PaymentMethod < SolidusSupport.payment_method_parent_class
     preference :merchant_id, :string
-    preference :iframe_url, :string
     preference :client_id, :string
     preference :client_secret, :string
-
-    validates :preferred_iframe_url,
-      inclusion: { in: %w[https://ecom.sandbox.acimacredit.com https://ecom.acimacredit.com] },
-      allow_blank: true
 
     def gateway_class
       ::SolidusAcima::Gateway
@@ -21,6 +16,10 @@ module SolidusAcima
 
     def partial_name
       "acima"
+    end
+
+    def preferred_iframe_url
+      preferred_test_mode ? 'https://ecom.sandbox.acimacredit.com' : 'https://ecom.acimacredit.com'
     end
   end
 end

--- a/db/migrate/20220315020041_remove_iframe_url_from_solidus_acima_payment_sources.rb
+++ b/db/migrate/20220315020041_remove_iframe_url_from_solidus_acima_payment_sources.rb
@@ -1,0 +1,5 @@
+class RemoveIframeUrlFromSolidusAcimaPaymentSources < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :solidus_acima_payment_sources, :iframe_url, :string
+  end
+end

--- a/lib/generators/solidus_acima/install/templates/initializer.rb
+++ b/lib/generators/solidus_acima/install/templates/initializer.rb
@@ -2,7 +2,6 @@
 
 SolidusAcima.configure do |config|
   config.acima_merchant_id = ENV.fetch('ACIMA_MERCHANT_ID', '')
-  config.acima_iframe_url = ENV.fetch('ACIMA_IFRAME_URL', '')
   config.acima_client_id = ENV.fetch('ACIMA_CLIENT_ID', '')
   config.acima_client_secret = ENV.fetch('ACIMA_CLIENT_SECRET', '')
 end

--- a/lib/solidus_acima/configuration.rb
+++ b/lib/solidus_acima/configuration.rb
@@ -2,7 +2,7 @@
 
 module SolidusAcima
   class Configuration
-    attr_accessor :acima_merchant_id, :acima_iframe_url, :acima_client_id, :acima_client_secret
+    attr_accessor :acima_merchant_id, :acima_client_id, :acima_client_secret
   end
 
   class << self

--- a/lib/solidus_acima/testing_support/factories.rb
+++ b/lib/solidus_acima/testing_support/factories.rb
@@ -3,7 +3,6 @@
 FactoryBot.define do
   factory :acima_payment_source, class: SolidusAcima::PaymentSource do
     merchant_id    { 'loca-3b73538c-b7ff-4b9b-b78e-f6906523ae16' }
-    iframe_url     { 'https://ecom.sandbox.acimacredit.com' }
     lease_id       { 'leas-f22d4693-b66e-4104-b4d8-ff20e4be1394' }
     lease_number   { '12345' }
     checkout_token { 'ecom-checkout-53511533-0f75-4942-82b9-5a6989871a03' }
@@ -12,7 +11,7 @@ FactoryBot.define do
 
   factory :acima_payment_method, class: SolidusAcima::PaymentMethod do
     name               { 'Acima' }
-    preferences        { { iframe_url: 'https://ecom.sandbox.acimacredit.com' } }
+    preferences        { { test_mode: true } }
     available_to_admin { true }
     available_to_users { true }
   end

--- a/spec/models/solidus_acima/gateway_spec.rb
+++ b/spec/models/solidus_acima/gateway_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'httparty'
 
 RSpec.describe SolidusAcima::Gateway, type: :model do
-  let(:gateway)        { described_class.new({ iframe_url: 'sandbox' }) }
+  let(:gateway)        { described_class.new({ test_mode: true }) }
   let(:payment_source) { create(:acima_payment_source) }
   let(:payment)        { create(:acima_payment) }
 

--- a/spec/models/solidus_acima/payment_source_spec.rb
+++ b/spec/models/solidus_acima/payment_source_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe SolidusAcima::PaymentSource, type: :model do
     [
       'id',
       'merchant_id',
-      'iframe_url',
       'payment_method_id',
       'lease_id',
       'lease_number',


### PR DESCRIPTION
Previously we requested users to input the iframe url that they would be using
for their application. However this URL only has 2 options: sandbox and production
and it's the same accross all vendors. To simplify setup and avoid errors when
copy-pasting the url, we've removed this input and instead will generate a url
based on whether the payment is marked as 'test_env: true' or not.
