### PR TITLE
Pass Address Details to Acima Automatically

### DIFF
--- a/app/assets/javascripts/solidus_acima.js
+++ b/app/assets/javascripts/solidus_acima.js
@@ -34,8 +34,9 @@ console.log([leaseId, leaseNumber, checkoutToken])
 
 // Call this function to start the Acima iframe process
 // on success send an API call to create a payment and advance to next step
-const createPayment = async (acima, transaction, orderNumber, orderToken, paymentMethodId, frontend) => {
+const createPayment = async (acima, customer, transaction, orderNumber, orderToken, paymentMethodId, frontend) => {
   acima.checkout({
+    customer: customer,
     transaction: transaction
   })
   .then(({ leaseId, leaseNumber, checkoutToken }) => {
@@ -96,6 +97,7 @@ document.addEventListener('DOMContentLoaded', async function () {
   const orderToken =      iframeContainer.dataset.orderToken
   const paymentMethodId = iframeContainer.dataset.paymentMethodId
   const transaction =     jsonParseReturningNumbers(iframeContainer.dataset.transaction)
+  const customer =        JSON.parse(iframeContainer.dataset.customer)
   const frontend =        iframeContainer.dataset.frontend == "true" ? true : false;
 
   const handlePaymentMethodSubmission = async (event) => {
@@ -105,7 +107,7 @@ document.addEventListener('DOMContentLoaded', async function () {
       // disable the submit button as we await payment creation
       cardButton.disabled = true;
       cardButton.style.display = 'none';
-      await createPayment(acima, transaction, orderNumber, orderToken, paymentMethodId, frontend);
+      await createPayment(acima, customer, transaction, orderNumber, orderToken, paymentMethodId, frontend);
     } catch (e) {
       cardButton.disabled = false;
       cardButton.style.display = '';

--- a/app/decorators/models/solidus_acima/order_decorator.rb
+++ b/app/decorators/models/solidus_acima/order_decorator.rb
@@ -23,6 +23,28 @@ module SolidusAcima
       }
     end
 
+    def json_acima_customer
+      acima_customer.to_json
+    end
+
+    def acima_customer
+      address = bill_address
+      {
+        firstName: address.name.split(' ').first,
+        middleName: address.name.split(' ')[1..-2].join(' '),
+        lastName: address.name.split(' ').last,
+        phone: address.phone,
+        email: email,
+        address: {
+          street1: address.address1,
+          street2: address.address2,
+          city: address.city,
+          state: address.state.abbr,
+          zipCode: address.zipcode,
+        }
+      }
+    end
+
     private
 
     def cents(float)

--- a/app/views/spree/shared/_acima.html.erb
+++ b/app/views/spree/shared/_acima.html.erb
@@ -3,6 +3,7 @@
   data-merchant-id="<%= payment_method.preferred_merchant_id %>"
   data-iframe-url="<%= payment_method.preferred_iframe_url %>"
   data-transaction="<%= @order.json_acima_transaction %>"
+  data-customer="<%= @order.json_acima_customer %>"
   data-order-number="<%= @order.number %>"
   data-order-token="<%= @order.guest_token %>"
   data-payment-method-id="<%= payment_method.id %>"

--- a/spec/decorators/models/solidus_acima/order_decorator_spec.rb
+++ b/spec/decorators/models/solidus_acima/order_decorator_spec.rb
@@ -15,4 +15,30 @@ RSpec.describe SolidusAcima::OrderDecorator do
       expect(order.json_acima_transaction).to eq(order.acima_transaction.to_json)
     end
   end
+
+  describe '#acima_customer' do
+    it 'returns a hash with customer data' do
+      result = {
+        email: order.email,
+        firstName: 'John',
+        middleName: 'Von',
+        lastName: 'Doe',
+        phone: '555-555-0199',
+        address: {
+          city: 'Herndon',
+          state: 'AL',
+          street1: 'PO Box 1337',
+          street2: 'Northwest',
+          zipCode: order.bill_address.zipcode
+        }
+      }
+      expect(order.acima_customer).to eq(result)
+    end
+  end
+
+  describe '#json_acima_customer' do
+    it 'returns a json version of the #acima_customer' do
+      expect(order.json_acima_customer).to eq(order.acima_customer.to_json)
+    end
+  end
 end


### PR DESCRIPTION
Before users would have to input their address details twice: once during
checkout, the other time to Acima. This is annoying from UX point of view
and since Acima offers a possibility to pass address details to simplify
this process this commit makes use of that possibility.
