### PR TITLE
Improve Refund's Logic

### DIFF
--- a/app/models/solidus_acima/gateway.rb
+++ b/app/models/solidus_acima/gateway.rb
@@ -26,7 +26,7 @@ module SolidusAcima
 
       url = "#{api_url}/contracts/#{source.lease_id}/delivery_confirmation"
       body = { selected_delivery_date: Time.zone.tomorrow.strftime("%F") }.to_json
-      response = HTTParty.put(url, headers: v2_headers.merge('Content-Type': 'application/json'), body: body)
+      response = HTTParty.put(url, headers: headers(2).merge('Content-Type': 'application/json'), body: body)
 
       if response.success?
         ActiveMerchant::Billing::Response.new(
@@ -53,7 +53,7 @@ module SolidusAcima
       payment_source = options[:originator].source
 
       url = "#{api_url}/applications/#{payment_source.lease_id}/cancel"
-      response = HTTParty.post(url, headers: v2_headers)
+      response = HTTParty.post(url, headers: headers(2))
 
       raise 'Acima Server Response Error: Did not get correct response code' unless response.success?
 
@@ -71,7 +71,7 @@ module SolidusAcima
 
       if acima_payment_captured?(lease_id)
         url = "#{api_url}/contracts/#{lease_id}/termination"
-        response = HTTParty.post(url, headers: v2_headers)
+        response = HTTParty.post(url, headers: headers(2))
 
         raise 'Acima Server Response Error: Did not get correct response code' unless response.success?
 
@@ -105,14 +105,13 @@ module SolidusAcima
       response['access_token']
     end
 
-    def v2_headers
-      { 'Authorization': "Bearer #{acima_bearer_token}", 'Accept': 'application/vnd.acima-v2+json' }
+    def headers(version)
+      { 'Authorization': "Bearer #{acima_bearer_token}", 'Accept': "application/vnd.acima-v#{version}+json" }
     end
 
     def acima_payment_captured?(lease_id)
       url = "#{api_url}/contracts/#{lease_id}/status"
-      headers = { 'Authorization': "Bearer #{acima_bearer_token}", 'Accept': 'application/vnd.acima-v1+json' }
-      response = HTTParty.get(url, headers: headers)
+      response = HTTParty.get(url, headers: headers(1))
       response.success?
     end
   end

--- a/spec/models/solidus_acima/gateway_spec.rb
+++ b/spec/models/solidus_acima/gateway_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe SolidusAcima::Gateway, type: :model do
         allow(api_response).to receive(:stringify_keys).and_return('')
       end
 
-      context 'when successful' do # rubocop:disable RSpec/NestedGroups
+      context 'when successful' do
         before { allow(api_response).to receive(:success?).and_return(true) }
 
         it 'creates a billing response' do
@@ -170,35 +170,59 @@ RSpec.describe SolidusAcima::Gateway, type: :model do
       subject(:credit_response) { gateway.credit(nil, payment_source.checkout_token, { originator: refund }) }
 
       let(:refund) { build(:refund, payment: payment) }
-      let(:api_response) { double(HTTParty) } # rubocop:disable RSpec/VerifiedDoubles
 
       before do
         payment.order.update(state: 'complete')
         payment.update(state: 'pending')
-        allow(HTTParty).to receive(:post).and_return(api_response)
-        allow(api_response).to receive(:stringify_keys).and_return('')
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(described_class).to receive(:acima_payment_captured?).and_return(acima_response)
+        # rubocop:enable RSpec/AnyInstance
       end
 
-      context 'when successful' do # rubocop:disable RSpec/NestedGroups
-        before { allow(api_response).to receive(:success?).and_return(true) }
+      # rubocop:disable RSpec/MultipleMemoizedHelpers
+      context 'with payment captured by Acima' do # rubocop:disable RSpec/NestedGroups
+        let(:acima_response) { true }
+        let(:api_response)   { double(HTTParty) } # rubocop:disable RSpec/VerifiedDoubles
 
-        it 'creates a billing response' do
-          expect(credit_response.class).to eq(ActiveMerchant::Billing::Response)
-        end
-
-        it 'the response returns true on #success?' do
-          expect(credit_response.success?).to eq(true)
-        end
-      end
-
-      context 'when failed' do # rubocop:disable RSpec/NestedGroups
         before do
-          allow(api_response).to receive(:success?).and_return(false)
-          allow(api_response).to receive(:code).and_return(415)
+          allow(HTTParty).to receive(:post).and_return(api_response)
+          allow(api_response).to receive(:stringify_keys).and_return('')
         end
 
-        it 'raises an error' do
-          expect { credit_response }.to raise_error(RuntimeError, /Acima Server Response Error:/)
+        context 'when successful' do # rubocop:disable RSpec/NestedGroups
+          before { allow(api_response).to receive(:success?).and_return(true) }
+
+          it 'creates a billing response' do
+            expect(credit_response.class).to eq(ActiveMerchant::Billing::Response)
+          end
+
+          it 'the response returns true on #success?' do
+            expect(credit_response.success?).to eq(true)
+          end
+        end
+
+
+        context 'when failed' do # rubocop:disable RSpec/NestedGroups
+          before do
+            allow(api_response).to receive(:success?).and_return(false)
+            allow(api_response).to receive(:code).and_return(415)
+          end
+
+          it 'raises an error' do
+            expect { credit_response }.to raise_error(RuntimeError, /Acima Server Response Error:/)
+          end
+        end
+      end
+      # rubocop:enable RSpec/MultipleMemoizedHelpers
+
+      context 'without payment captured by Acima' do # rubocop:disable RSpec/NestedGroups
+        let(:acima_response) { false }
+
+        before { allow_any_instance_of(described_class).to receive(:void) } # rubocop:disable RSpec/AnyInstance
+
+        it 'calls #void' do
+          expect_any_instance_of(described_class).to receive(:void) # rubocop:disable RSpec/AnyInstance
+          credit_response
         end
       end
     end


### PR DESCRIPTION
An Acima's lease request takes some time to process so it can happen that even though a payment has been captured on Solidus' side, it still hasn't been on Acima's side. If we send a refund request before Acima has processed it, it will return an error.

Until now we have relied on vendors to watch out for this, but with this commit we implement logic to check the current capture status on Acima's side and based on that either follow with #credit's logic or revert to #void's logic."