### PR TITLE
Fix #credit error

### DIFF
--- a/app/models/solidus_acima/gateway.rb
+++ b/app/models/solidus_acima/gateway.rb
@@ -26,7 +26,7 @@ module SolidusAcima
 
       url = "#{api_url}/contracts/#{source.lease_id}/delivery_confirmation"
       body = { selected_delivery_date: Time.zone.tomorrow.strftime("%F") }.to_json
-      response = HTTParty.put(url, headers: v2_headers.merge('Content-Type': 'application/json'), body: body)
+      response = HTTParty.put(url, headers: headers(2).merge('Content-Type': 'application/json'), body: body)
 
       if response.success?
         ActiveMerchant::Billing::Response.new(
@@ -53,7 +53,7 @@ module SolidusAcima
       payment_source = options[:originator].source
 
       url = "#{api_url}/applications/#{payment_source.lease_id}/cancel"
-      response = HTTParty.post(url, headers: v2_headers)
+      response = HTTParty.post(url, headers: headers(2))
 
       raise 'Acima Server Response Error: Did not get correct response code' unless response.success?
 
@@ -69,7 +69,7 @@ module SolidusAcima
       payment_source = options[:originator].payment.source
 
       url = "#{api_url}/contracts/#{payment_source.lease_id}/termination"
-      response = HTTParty.post(url, headers: v2_headers)
+      response = HTTParty.post(url, headers: headers(2))
 
       raise 'Acima Server Response Error: Did not get correct response code' unless response.success?
 
@@ -83,8 +83,7 @@ module SolidusAcima
 
     def acima_payment_captured?(lease_id)
       url = "#{api_url}/contracts/#{lease_id}/status"
-      headers = { 'Authorization': "Bearer #{acima_bearer_token}", 'Accept': 'application/vnd.acima-v1+json' }
-      response = HTTParty.get(url, headers: headers)
+      response = HTTParty.get(url, headers: headers(1))
       response.success?
     end
 
@@ -107,8 +106,8 @@ module SolidusAcima
       response['access_token']
     end
 
-    def v2_headers
-      { 'Authorization': "Bearer #{acima_bearer_token}", 'Accept': 'application/vnd.acima-v2+json' }
+    def headers(version)
+      { 'Authorization': "Bearer #{acima_bearer_token}", 'Accept': "application/vnd.acima-v#{version}+json" }
     end
   end
 end

--- a/app/models/solidus_acima/gateway.rb
+++ b/app/models/solidus_acima/gateway.rb
@@ -81,6 +81,13 @@ module SolidusAcima
       )
     end
 
+    def acima_payment_captured?(lease_id)
+      url = "#{api_url}/contracts/#{lease_id}/status"
+      headers = { 'Authorization': "Bearer #{acima_bearer_token}", 'Accept': 'application/vnd.acima-v1+json' }
+      response = HTTParty.get(url, headers: headers)
+      response.success?
+    end
+
     private
 
     def generate_bearer_token(client_id, client_secret)

--- a/app/models/solidus_acima/payment_source.rb
+++ b/app/models/solidus_acima/payment_source.rb
@@ -4,5 +4,8 @@ require_dependency 'solidus_acima'
 
 module SolidusAcima
   class PaymentSource < SolidusSupport.payment_source_parent_class
+    def can_credit?(payment)
+      payment.payment_method.gateway.acima_payment_captured?(payment.source.lease_id)
+    end
   end
 end

--- a/spec/models/solidus_acima/payment_source_spec.rb
+++ b/spec/models/solidus_acima/payment_source_spec.rb
@@ -25,4 +25,17 @@ RSpec.describe SolidusAcima::PaymentSource, type: :model do
       expect(described_class.new.attributes.keys.sort).to eq(column_list)
     end
   end
+
+  describe '#can_credit?' do
+    let(:gateway)        { SolidusAcima::Gateway.new({ test_mode: true }) }
+    let(:payment_source) { create(:acima_payment_source) }
+    let(:payment)        { create(:acima_payment) }
+
+    it 'calls Gateway#acima_payment_captured?' do
+      # rubocop:disable RSpec/MessageChain
+      expect(payment).to receive_message_chain(:payment_method, :gateway, :acima_payment_captured?)
+      # rubocop:enable RSpec/MessageChain
+      described_class.new.can_credit?(payment)
+    end
+  end
 end


### PR DESCRIPTION
Calling #credit on an order that hasn't been yet processed by Acima will result in an error. To avoid that we'll make an API call to Acima and display the refund option based on its status."